### PR TITLE
Fixing HEX to RGB conversion (as it was broken)

### DIFF
--- a/src/skrollr-colors.js
+++ b/src/skrollr-colors.js
@@ -9,7 +9,7 @@
     // We convert HEX to RGBA, then we'll convert RGBA to HSLA (I'd like to find a way to convert HEX>HSLA in one step)
 
     function hexToRgba(hex) {
-        var result = /#([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9])([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9])([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9])/g.exec(hex);
+        var result = /^#?([a-fA-F\d]{1,2})([a-fA-F\d]{1,2})([a-fA-F\d]{1,2})$/g.exec(hex);
         return "rgba(" + parseInt(result[1], 16) + "," + parseInt(result[2], 16) + "," + parseInt(result[3], 16) + ",1)";
     }
 


### PR DESCRIPTION
The color conversion for 6 character Hex codes was very busted for me. This regex is simpler - and works cleanly. 
